### PR TITLE
Init autoinstall configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ Introduction of Ubuntu Server guide](Automated Server Installs Introduction) for
 
 You can also add additional kernel command line arguments (e.g. `"console=ttyS0"`) to the generated configuration files using the `--extra-args` parameter.
 
-## Usage
+## Usage of the Generated Files
 Copy the files generated under the interim folder `/tmp/tmpxxx/ubuntu-installer/`
-to your tftp root folder for netboot, for example `/var/lib/tftpboot`:
+to your tftp root folder for netboot, for example `/srv/tftp` or `/var/lib/tftpboot`.
+You may check your tftpd configuration of the root directory, for instance, tftpd-hpa is `/etc/default/tftpd-hpa`. Let's copy:
 
 ```
-$ sudo cp /tmp/tmpxxx/ubuntu-installer/* /var/lib/tftpboot/
+$ sudo cp -r /tmp/tmpxxx/ubuntu-installer/* /srv/tftp
 ```
 
 Then your netboot server is ready to go if the corresponding DHCP is set up.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ The `--url` parameter is used for 2 reasons:
 
 If you have a local copy of the ISO, you can point to it with the `--iso` parameter to avoid having `ubuntu-server-netboot.py` download an extra copy. Just be sure that `--iso` and `--url` point to the same version of the ISO.
 
+Optionally, you can place `--autoinstall-url` to tell the netbooting process to enable subiquity automation. See [our autoinstall example](./autoinstall/README.md) and [the autoinstall and Automated Server Installs
+Introduction of Ubuntu Server guide](Automated Server Installs Introduction) for more details.
+
 You can also add additional kernel command line arguments (e.g. `"console=ttyS0"`) to the generated configuration files using the `--extra-args` parameter.
 
 ## Usage

--- a/autoinstall/README.md
+++ b/autoinstall/README.md
@@ -1,0 +1,17 @@
+# Autoinstall
+By using autoinstall we could automate the subiquity installer like what `preseed` is used for `debian-installer`, a.k.a. `d-i`.
+
+## Usage
+1. Upload your `user-data` to a www server. You may use `basic.yaml` as an example. Rename `basic.yaml` to be `user-data` and put it into a www server to serve it. By using `basic.yaml` the default username and password will be both `ubuntu`. You can change the default username and password by following the instruction in the comment block of `basic.yaml`.
+2. `touch <your www server>/meta-data` to create an empty but necessary file required by `cloud-init`.
+3. Include the necessary kernel parameters `autoinstall "ds=nocloud-net;s=http://<www-server-url>/"`. For UEFI, it is usually the line of `linux` in your `grub.cfg`. If you are working on `pxelinux.cfg` for legacy mode, please do something similar in your `APPEND` line. For example,
+     - as is `quiet splash root=/dev/ram0 ramdisk_size=1500000 ip=dhcp url=http://<server-provides-image>/focal-live-server-arm64.iso ---`
+     - to be `quiet splash root=/dev/ram0 ramdisk_size=1500000 ip=dhcp url=http://<server-provides-image>/focal-live-server-arm64.iso autoinstall "ds=nocloud-net;s=http://<server-provides-user-data>/" ---`
+
+## Trouble-shooting and Tips
+- The format of the first line "shebang", a.k.a. `#cloud-config` matters. Do not change it or input extra spaces
+  unless you know what you are doing.
+- The double quotes matter when injecting `user-data` in the kernel parameters.
+- The file name `user-data` is a must. Its the file name that `cloud-init` will look for.
+- The file `meta-data` is also a must, even it is an empty file in our example.
+- The trailing slash of the url serving `user-data` matters in the current autoinstall version.

--- a/autoinstall/basic.yaml
+++ b/autoinstall/basic.yaml
@@ -1,0 +1,14 @@
+#cloud-config
+autoinstall:
+  version: 1
+  identity:
+    hostname: ubuntu-server
+    # The password hash maps to "ubuntu".
+    # See the example of Ubuntu Server guide https://ubuntu.com/server/docs/install/autoinstall-quickstart
+    #
+    # You may generate your own password by:
+    #   mkpasswd --method=SHA-512 --rounds=4096
+    # Refer to the document of cloudinit for generating password
+    # https://cloudinit.readthedocs.io/en/latest/topics/examples.html
+    password: "$6$exDY1mhS4KUYCE/2$zmn9ToZwTKLhCw.b4/b.ZRTIZM30JZ4QrOQ2aOXJ8yk96xpcCof0kxKwuX1kqLG/ygbJ1f8wxED22bTL4F46P0"
+    username: ubuntu


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

- **New feature**
- **Documentation Update**

## Description
<!--Describe what the change is**-->
Inspired by [this discourse post "Please test autoinstalls for 20.04!"](https://discourse.ubuntu.com/t/please-test-autoinstalls-for-20-04/15250), I think that both autoinstall and ubuntu-server-netboot are getting much more mature to use. This pull request initiate the implementation to integrate both of them, so we may look forward to automating our pxe testing process.

## Steps to Test This Pull Request
1. Grab a UEFI bare metal, and deploy focal to it.
2. install prerequisite package dependencies.
2. (on the deployed focal) `ubuntu-server-netboot$ sudo ./ubuntu-server-netboot.py --url http://cdimage.ubuntu.com/ubuntu/releases/20.04.2/release/ubuntu-20.04.2-live-server-arm64.iso --autoinstall-url http://<IP OF YOUR FOCAL>/`


Platform tested: awrep6 (netboot server), d05-2, scobee


## Expected Result
`ubuntu-installer/grub/grub.cfg` now has the inserted snippet ` autoinstall "ds=nocloud-net;s=http://<IP OF YOUR FOCAL>/" ` before `---`.


## Additional context
<!--Add any other context or screenshots about the pull request here.-->
[Ubuntu Server Guide - Autoinstall Quick Start](https://ubuntu.com/server/docs/install/autoinstall-quickstart)
[Ubuntu Server Guide - Autoinstall](https://ubuntu.com/server/docs/install/autoinstall)

