### PR TITLE
README: update for iso link in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This utility generates a netboot directory tree from an Ubuntu Server Live ISO image, an image based on the `subiquity` installer. The tree contents are similar to the contents of the `netboot.tar.gz` file that debian-installer builds provide. Example:
 
 ```
-$ ./ubuntu-server-netboot.py --url http://releases.ubuntu.com/focal/ubuntu-20.04.1-live-server-amd64.iso
+$ ./ubuntu-server-netboot.py --url http://releases.ubuntu.com/focal/ubuntu-20.04.2-live-server-amd64.iso
 INFO: Downloading http://releases.ubuntu.com/focal/ubuntu-20.04.1-live-server-amd64.iso
 INFO: Attempting to download http://archive.ubuntu.com/ubuntu/dists/focal-updates/main/uefi/grub2-amd64/current/grubx64.efi.signed
 INFO: Netboot generation complete: /tmp/tmpo54145m2/ubuntu-installer


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->
- **Documentation Update**

## Description
<!--Describe what the change is**-->
20.04.2 is released and the original link for 20.04.1 does not work anymore.

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
Maybe we could use this link instead `http://old-releases.ubuntu.com/releases/focal/ubuntu-20.04.1-live-server-amd64.iso` so the link in the example will be more permanent.