### PR TITLE
fix: fix missing kernel parameters of autoinstall

### DIFF
--- a/ubuntu-server-netboot.py
+++ b/ubuntu-server-netboot.py
@@ -222,7 +222,7 @@ def setup_kernel_params(bootloader_cfg):
     if args.autoinstall_url:
         bootloader_cfg.add_kernel_params(
             [
-                "ds=nocloud-net;s=%s" % (args.autoinstall_url),
+                'autoinstall "ds=nocloud-net;s=%s"' % (args.autoinstall_url),
             ],
             install_only=True
         )


### PR DESCRIPTION
## Types of changes
<!--Please remove the types that does not apply to this change-->

- **Bugfix**

## Description
<!--Describe what the change is**-->
In 35fe544d44c236facc399d0b39709d952360a8fb to refactoring code we are missing some necessary arguments and special characters for typo. This commit is a fixup to make sure we get the same result before re-factoring.

## Checklist:
- [ ] Add test cases to all the changes you introduce
- [ ] Run `poetry run pytest` locally to ensure all linter checks pass
- [ ] Update the documentation if necessary

## Steps to Test This Pull Request
1. checkout to the previous commit of 35fe544d44c236facc399d0b39709d952360a8fb
2. generate grub.cfg
3. checkout to this commit
4. generate grub.cfg again

## Expected Behavior
<!--A clear and concise description of what you expected to happen-->
The content of grub.cfg from step 2 and 4 are the same.

## Actual Result
As-is
```
ubuntu@awrep6:~$ diff ~/unittest/grub.base.cfg /srv/tftp/grub/grub.cfg
10c10
<       linux   /casper/vmlinuz quiet root=/dev/ram0 ramdisk_size=1500000 ip=dhcp url=https://cdimage.ubuntu.com/releases/21.04/release/ubuntu-21.04-live-server-arm64.iso autoinstall "ds=nocloud-net;s=http://10.228.68.112/" ---
---
>       linux   /casper/vmlinuz quiet root=/dev/ram0 ramdisk_size=1500000 ip=dhcp url=https://cdimage.ubuntu.com/releases/21.04/release/ubuntu-21.04-live-server-arm64.iso ds=nocloud-net;s=http://10.228.68.112/ ---
18a19
>

```

And the `grub.cfg` won't provision autoinstall correctly so the installer stops at the prompt of subiquity.


To-be (one empty line is ok) 
```
ubuntu@awrep6:~$ diff ~/unittest/grub.base.cfg /srv/tftp/grub/grub.cfg
19a20
>
```
The grub.cfg sh has been tested with awrep6(server) and d05-1(client).
