### PR TITLE
Introduce poetry python package management tool (deprecated)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,16 @@
+Copyright (C) 2020 Canonical, Ltd.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This utility generates a netboot directory tree from an Ubuntu Server Live ISO image, an image based on the `subiquity` installer. The tree contents are similar to the contents of the `netboot.tar.gz` file that debian-installer builds provide. Example:
 
 ```
-$ ./ubuntu-server-netboot.py --url http://releases.ubuntu.com/focal/ubuntu-20.04.2-live-server-amd64.iso
+$ ./ubuntu-server-netboot --url http://releases.ubuntu.com/focal/ubuntu-20.04.2-live-server-amd64.iso
 INFO: Downloading http://releases.ubuntu.com/focal/ubuntu-20.04.2-live-server-amd64.iso
 INFO: Attempting to download http://archive.ubuntu.com/ubuntu/dists/focal-updates/main/uefi/grub2-amd64/current/grubx64.efi.signed
 INFO: Netboot generation complete: /tmp/tmpo54145m2/ubuntu-installer
@@ -10,10 +10,10 @@ INFO: Netboot generation complete: /tmp/tmpo54145m2/ubuntu-installer
 
 The `--url` parameter is used for 2 reasons:
 
-1. `ubuntu-server-netboot.py` will download the image at runtime to extract the necessary files from it.
-1. Subiquity-based installs need to download an image at install-time. `ubuntu-server-netboot.py` will generate configuration files that point the installer to this URL.
+1. `ubuntu-server-netboot` will download the image at runtime to extract the necessary files from it.
+1. Subiquity-based installs need to download an image at install-time. `ubuntu-server-netboot` will generate configuration files that point the installer to this URL.
 
-If you have a local copy of the ISO, you can point to it with the `--iso` parameter to avoid having `ubuntu-server-netboot.py` download an extra copy. Just be sure that `--iso` and `--url` point to the same version of the ISO.
+If you have a local copy of the ISO, you can point to it with the `--iso` parameter to avoid having `ubuntu-server-netboot` download an extra copy. Just be sure that `--iso` and `--url` point to the same version of the ISO.
 
 Optionally, you can place `--autoinstall-url` to tell the netbooting process to enable subiquity automation. See [our autoinstall example](./autoinstall/README.md) and [the autoinstall and Automated Server Installs
 Introduction of Ubuntu Server guide](Automated Server Installs Introduction) for more details.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,8 @@
+package = []
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.6.5"
+content-hash = "29ae350c98a4a6bdf0f8304a04012ec1a015e20144daccc63bc0ef40f8015e1b"
+
+[metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "usn"
+version = "0.1.0"
+description = "This utility generates a netboot directory tree from an Ubuntu Server Live ISO image, an image based on the subiquity installer."
+authors = ["Taihsiang Ho (tai271828) <taihsiang.ho@canonical.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.6.5"
+
+[tool.poetry.dev-dependencies]
+
+[tool.poetry.scripts]
+ubuntu-server-netboot = "usn.usn:ubuntu_server_netboot"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/ubuntu-server-netboot
+++ b/ubuntu-server-netboot
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+#
+from usn.usn import ubuntu_server_netboot
+
+
+if __name__ == "__main__":
+    ubuntu_server_netboot()

--- a/usn/ubuntu_server_netboot.py
+++ b/usn/ubuntu_server_netboot.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-#
 # Copyright (C) 2020 Canonical, Ltd.
 #
 # This program is free software; you can redistribute it and/or
@@ -16,19 +14,19 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
-import argparse
-import atexit
 import distro_info
-import logging
 import os
 import re
 import shutil
 import subprocess
-import sys
-import tempfile
 import urllib.request
 
+
 Netboot_Args = ["root=/dev/ram0", "ramdisk_size=1500000", "ip=dhcp"]
+Ubuntu_Arch_to_Uefi_Arch_Abbrev = {
+    "amd64": "x64",
+    "arm64": "aa64",
+}
 
 
 class UbuntuDistroInfoWithVersionSupport(distro_info.UbuntuDistroInfo):
@@ -166,13 +164,7 @@ def select_mirror(arch):
         return "http://ports.ubuntu.com/ubuntu-ports"
 
 
-Ubuntu_Arch_to_Uefi_Arch_Abbrev = {
-    "amd64": "x64",
-    "arm64": "aa64",
-}
-
-
-def download_bootnet(release, architecture, destdir):
+def download_bootnet(release, architecture, destdir, logger):
     uefi_arch_abbrev = Ubuntu_Arch_to_Uefi_Arch_Abbrev[architecture]
     for pocket in ["%s-updates" % (release), release]:
         url = "%s/dists/%s/main/uefi/grub2-%s/current/grubnet%s.efi.signed" % (
@@ -194,7 +186,7 @@ def download_bootnet(release, architecture, destdir):
     raise Exception("Could not download %s" % (url))
 
 
-def download_pxelinux(release, destdir):
+def download_pxelinux(release, destdir, logger):
     for pocket in ["%s-updates" % (release), release]:
         mirror = select_mirror("amd64")
         url = (
@@ -214,134 +206,21 @@ def download_pxelinux(release, destdir):
     raise Exception("Could not download %s" % (url))
 
 
-def setup_kernel_params(bootloader_cfg):
+def setup_kernel_params(bootloader_cfg, url, autoinstall_url, extra_args):
     bootloader_cfg.add_kernel_params(
-        Netboot_Args + ["url=%s" % (args.url)], install_only=True
+        Netboot_Args + ["url=%s" % (url)], install_only=True
     )
-    if args.autoinstall_url:
+    if autoinstall_url:
         bootloader_cfg.add_kernel_params(
             [
-                'autoinstall "ds=nocloud-net;s=%s"' % (args.autoinstall_url),
+                'autoinstall "ds=nocloud-net;s=%s"' % (autoinstall_url),
             ],
             install_only=True,
         )
-    if args.extra_args:
-        bootloader_cfg.add_kernel_params(args.extra_args.split(" "))
+    if extra_args:
+        bootloader_cfg.add_kernel_params(extra_args.split(" "))
 
 
-def cleanup(directory):
+def cleanup(directory, logger):
     logger.info("Cleaning up %s" % (directory))
     shutil.rmtree(directory)
-
-
-if __name__ == "__main__":
-    logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
-    ch = logging.StreamHandler()
-    formatter = logging.Formatter("%(levelname)s: %(message)s")
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
-
-    parser = argparse.ArgumentParser(
-        description="Generate a netboot tree from an Ubuntu Server live ISO"
-    )
-    parser.add_argument(
-        "-e",
-        "--extra-args",
-        help="Any additional kernel command line arguments",
-    )
-    parser.add_argument(
-        "--iso",
-        help="Local copy of Server Live ISO"
-        + " (--url should point to a copy of the same file)",
-    )
-    parser.add_argument(
-        "-o",
-        "--out-dir",
-        help="Output directory",
-    )
-    parser.add_argument(
-        "--url",
-        help="URL to Server Live ISO to be downloaded at install-time",
-        required=True,
-    )
-    parser.add_argument(
-        "--autoinstall-url",
-        help="URL to Autoinstall config file to be used during Subiquity installation",
-    )
-
-    args = parser.parse_args()
-    if args.iso:
-        iso = ServerLiveIso(args.iso)
-    else:
-        logger.info("Downloading %s" % (args.url))
-        with urllib.request.urlopen(args.url) as response:
-            with tempfile.NamedTemporaryFile(delete=False) as iso:
-                atexit.register(os.remove, iso.name)
-                shutil.copyfileobj(response, iso)
-                iso = ServerLiveIso(iso.name)
-
-    architecture = iso.architecture
-    release = iso.codename
-
-    staging_root = args.out_dir or tempfile.mkdtemp()
-    staging_dir = os.path.join(staging_root, "ubuntu-installer")
-    os.mkdir(staging_dir)
-    if args.out_dir:
-        atexit.register(cleanup, staging_dir)
-    else:
-        atexit.register(cleanup, staging_root)
-
-    download_bootnet(release, architecture, staging_dir)
-
-    os.mkdir(os.path.join(staging_dir, "casper"))
-    for f in ["vmlinuz", "initrd"]:
-        iso.extract_file(
-            os.path.join(os.sep, "casper", f),
-            os.path.join(staging_dir, "casper", f),
-        )
-    try:
-        for hwe_f in ["hwe-vmlinuz", "hwe-initrd"]:
-            iso.extract_file(
-                os.path.join(os.sep, "casper", hwe_f),
-                os.path.join(staging_dir, "casper", hwe_f),
-            )
-    except FileNotFoundError:
-        logger.info("No HWE boot files found, skipping")
-        pass
-
-    grub_cfg_orig = iso.read_file(os.path.join(os.sep, "boot", "grub", "grub.cfg"))
-    grub_cfg = GrubConfig(grub_cfg_orig.decode("utf-8"))
-    setup_kernel_params(grub_cfg)
-
-    os.mkdir(os.path.join(staging_dir, "grub"))
-    with open(os.path.join(staging_dir, "grub", "grub.cfg"), "w") as grub_f:
-        grub_f.write(str(grub_cfg))
-
-    if architecture == "amd64":
-        local_files = [
-            (os.path.join(os.sep, "usr", "lib", "PXELINUX", "pxelinux.0"), "pxelinux"),
-            (
-                os.path.join(
-                    os.sep, "usr", "lib", "syslinux", "modules", "bios", "ldlinux.c32"
-                ),
-                "syslinux-common",
-            ),
-        ]
-        for (local_file, pkg) in local_files:
-            try:
-                shutil.copy(local_file, staging_dir)
-            except FileNotFoundError as err:
-                sys.stderr.write("%s\n" % (err))
-                sys.stderr.write("Try installing %s.\n" % (pkg))
-                sys.exit(1)
-
-        pxelinux_dir = os.path.join(staging_dir, "pxelinux.cfg")
-        os.mkdir(pxelinux_dir)
-        pxelinux_cfg = PxelinuxConfig()
-        setup_kernel_params(pxelinux_cfg)
-        with open(os.path.join(pxelinux_dir, "default"), "w") as pxelinux_f:
-            pxelinux_f.write(str(pxelinux_cfg))
-
-    atexit.unregister(cleanup)
-    logger.info("Netboot generation complete: %s" % (staging_dir))

--- a/usn/usn.py
+++ b/usn/usn.py
@@ -56,7 +56,7 @@ def ubuntu_server_netboot():
     if args.iso:
         iso = ServerLiveIso(args.iso)
     else:
-        logger.info("Downloading %s" % (args.url))
+        logger.info("Downloading %s" % args.url)
         with urllib.request.urlopen(args.url) as response:
             with tempfile.NamedTemporaryFile(delete=False) as iso:
                 atexit.register(os.remove, iso.name)
@@ -114,16 +114,18 @@ def ubuntu_server_netboot():
             try:
                 shutil.copy(local_file, staging_dir)
             except FileNotFoundError as err:
-                sys.stderr.write("%s\n" % (err))
-                sys.stderr.write("Try installing %s.\n" % (pkg))
+                sys.stderr.write("%s\n" % err)
+                sys.stderr.write("Try installing %s.\n" % pkg)
                 sys.exit(1)
 
         pxelinux_dir = os.path.join(staging_dir, "pxelinux.cfg")
         os.mkdir(pxelinux_dir)
         pxelinux_cfg = PxelinuxConfig()
-        setup_kernel_params(pxelinux_cfg)
+        setup_kernel_params(
+            pxelinux_cfg, args.url, args.autoinstall_url, args.extra_args
+        )
         with open(os.path.join(pxelinux_dir, "default"), "w") as pxelinux_f:
             pxelinux_f.write(str(pxelinux_cfg))
 
     atexit.unregister(cleanup)
-    logger.info("Netboot generation complete: %s" % (staging_dir))
+    logger.info("Netboot generation complete: %s" % staging_dir)

--- a/usn/usn.py
+++ b/usn/usn.py
@@ -1,0 +1,129 @@
+import argparse
+import atexit
+import logging
+import os
+import shutil
+import sys
+import tempfile
+import urllib.request
+from usn.ubuntu_server_netboot import (
+    GrubConfig,
+    ServerLiveIso,
+    PxelinuxConfig,
+    cleanup,
+    download_bootnet,
+    setup_kernel_params,
+)
+
+
+def ubuntu_server_netboot():
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    ch = logging.StreamHandler()
+    formatter = logging.Formatter("%(levelname)s: %(message)s")
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    parser = argparse.ArgumentParser(
+        description="Generate a netboot tree from an Ubuntu Server live ISO"
+    )
+    parser.add_argument(
+        "-e",
+        "--extra-args",
+        help="Any additional kernel command line arguments",
+    )
+    parser.add_argument(
+        "--iso",
+        help="Local copy of Server Live ISO"
+        + " (--url should point to a copy of the same file)",
+    )
+    parser.add_argument(
+        "-o",
+        "--out-dir",
+        help="Output directory",
+    )
+    parser.add_argument(
+        "--url",
+        help="URL to Server Live ISO to be downloaded at install-time",
+        required=True,
+    )
+    parser.add_argument(
+        "--autoinstall-url",
+        help="URL to Autoinstall config file to be used during Subiquity installation",
+    )
+
+    args = parser.parse_args()
+    if args.iso:
+        iso = ServerLiveIso(args.iso)
+    else:
+        logger.info("Downloading %s" % (args.url))
+        with urllib.request.urlopen(args.url) as response:
+            with tempfile.NamedTemporaryFile(delete=False) as iso:
+                atexit.register(os.remove, iso.name)
+                shutil.copyfileobj(response, iso)
+                iso = ServerLiveIso(iso.name)
+
+    architecture = iso.architecture
+    release = iso.codename
+
+    staging_root = args.out_dir or tempfile.mkdtemp()
+    staging_dir = os.path.join(staging_root, "ubuntu-installer")
+    os.mkdir(staging_dir)
+    if args.out_dir:
+        atexit.register(cleanup, staging_dir, logger)
+    else:
+        atexit.register(cleanup, staging_root, logger)
+
+    download_bootnet(release, architecture, staging_dir, logger)
+
+    os.mkdir(os.path.join(staging_dir, "casper"))
+    for f in ["vmlinuz", "initrd"]:
+        iso.extract_file(
+            os.path.join(os.sep, "casper", f),
+            os.path.join(staging_dir, "casper", f),
+        )
+    try:
+        for hwe_f in ["hwe-vmlinuz", "hwe-initrd"]:
+            iso.extract_file(
+                os.path.join(os.sep, "casper", hwe_f),
+                os.path.join(staging_dir, "casper", hwe_f),
+            )
+    except FileNotFoundError:
+        logger.info("No HWE boot files found, skipping")
+        pass
+
+    grub_cfg_orig = iso.read_file(os.path.join(os.sep, "boot", "grub", "grub.cfg"))
+    grub_cfg = GrubConfig(grub_cfg_orig.decode("utf-8"))
+    setup_kernel_params(grub_cfg, args.url, args.autoinstall_url, args.extra_args)
+
+    os.mkdir(os.path.join(staging_dir, "grub"))
+    with open(os.path.join(staging_dir, "grub", "grub.cfg"), "w") as grub_f:
+        grub_f.write(str(grub_cfg))
+
+    if architecture == "amd64":
+        local_files = [
+            (os.path.join(os.sep, "usr", "lib", "PXELINUX", "pxelinux.0"), "pxelinux"),
+            (
+                os.path.join(
+                    os.sep, "usr", "lib", "syslinux", "modules", "bios", "ldlinux.c32"
+                ),
+                "syslinux-common",
+            ),
+        ]
+        for (local_file, pkg) in local_files:
+            try:
+                shutil.copy(local_file, staging_dir)
+            except FileNotFoundError as err:
+                sys.stderr.write("%s\n" % (err))
+                sys.stderr.write("Try installing %s.\n" % (pkg))
+                sys.exit(1)
+
+        pxelinux_dir = os.path.join(staging_dir, "pxelinux.cfg")
+        os.mkdir(pxelinux_dir)
+        pxelinux_cfg = PxelinuxConfig()
+        setup_kernel_params(pxelinux_cfg)
+        with open(os.path.join(pxelinux_dir, "default"), "w") as pxelinux_f:
+            pxelinux_f.write(str(pxelinux_cfg))
+
+    atexit.unregister(cleanup)
+    logger.info("Netboot generation complete: %s" % (staging_dir))


### PR DESCRIPTION
## Types of changes
- **New feature**
- **Refactoring**
- **Breaking change** (any change that would cause existing functionality to not work as expected)
- **Documentation Update**


## Description
Per our discussion on MM, we will `poetry` to manage `ubuntu-server-netboot` as a python package for the distribution purpose later, and development of test cases.

## Checklist:
- [ ] Add test cases to all the changes you introduce
- [ ] Run `poetry run pytest` locally to ensure all linter checks pass
- [ ] Update the documentation if necessary

## Steps to Test This Pull Request
Follow the updated `README` and it should generate the same content of `grub.cfg` as what its previous codebase does. What the only change a user will be aware of is the command name migrating to `ubuntu-server-netboot` from `ubuntu-server-netboot.py`.

## Expected behavior
<!--A clear and concise description of what you expected to happen-->
`grub.cfg` is the same. No regression of `grub.cfg`.

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->
https://github.com/dannf/ubuntu-server-netboot/issues/18

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
After we land this pull request, I will build the python package and update the README to show how to install `ubuntu-server-netboot` as a python package from PyPI or as a deb package from PPA directly. We will address this issue in more details later.
