### PR TITLE
Get ready to release ubuntu-server-netboot 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,23 @@
 [tool.poetry]
-name = "usn"
-version = "0.1.0"
+name = "ubuntu-server-netboot"
+packages = [
+    {include = "usn"}
+]
+version = "0.1.1rc4"
 description = "This utility generates a netboot directory tree from an Ubuntu Server Live ISO image, an image based on the subiquity installer."
 authors = ["dann frazier <dannf@ubuntu.com>", "Taihsiang Ho (tai271828) <taihsiangho@ubuntu.com>"]
+license = "GPL-2.0-only"
+readme = "README.md"
+classifiers = [
+    "Topic :: System :: Installation/Setup",
+    "Topic :: Utilities",
+    "Development Status :: 6 - Mature",
+    "Programming Language :: Python :: 3 :: Only",
+    "Operating System :: POSIX",
+    "Environment :: Console",
+    "Intended Audience :: System Administrators",
+    "Natural Language :: English",
+]
 
 [tool.poetry.dependencies]
 python = "^3.6.5"


### PR DESCRIPTION
## Types of changes
- **Documentation Update**

## Description
docs(package): rename usn and update meta data



## Checklist:
- [ ] Add test cases to all the changes you introduce
- [ ] Run `poetry run pytest` locally to ensure all linter checks pass
- [x] Update the documentation if necessary

## Steps to Test This Pull Request
1. `poetry build`
2. one-off: `poetry config repositories.testpypi https://test.pypi.org/legacy/`
3. `poetry publish -r testpypi` to release to testing/staging pypi https://test.pypi.org/project/ubuntu-server-netboot/
4. `poetry publish` to release to official/production https://pypi.org/project/ubuntu-server-netboot/


## Expected behavior
page on testpypi https://test.pypi.org/project/ubuntu-server-netboot/0.1.1rc3/
page on pypi https://pypi.org/project/ubuntu-server-netboot/0.1.1rc3/

Some fields highlighted to be noticed when reviewing:
- package name should be `ubuntu-server-netboot` (not `usn`)
- licence
- fields of clissifiers
- rendering of package description (should be the same as `README`)


## Additional Information
- If everything looks good, then `pip install ubuntu-server-boot` could make `ubuntu-server-boot` command line tool ready in your system without worrying manual dependency setup.
- When this pull request is landed, the version will bump from `0.1.1rc3` to `0.1.1`.


## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->
issue: #18

